### PR TITLE
Changing mysql to mysqli

### DIFF
--- a/web/pages/dailyawardinfo.php
+++ b/web/pages/dailyawardinfo.php
@@ -142,7 +142,7 @@ For support and installation notes visit http://www.hlxcommunity.com
 			awardid=$award	
 	");
 
-	$numitems = mysql_num_rows($resultCount);
+	$numitems = mysqli_num_rows($resultCount);
 
 ?>
 


### PR DESCRIPTION
Changing $numitems = mysql_num_rows($resultCount); to $numitems = mysqli_num_rows($resultCount); to contemplate the new mysqli* function calls existent on newer php versions, as this function was deprecated in PHP 5.5.0, and it was removed in PHP 7.0.0
See https://www.php.net/manual/en/function.mysql-num-rows.php for more info on this function.
