### PR TITLE
Split function was removed in PHP 7

### DIFF
--- a/web/pages/players.php
+++ b/web/pages/players.php
@@ -344,7 +344,7 @@ For support and installation notes visit http://www.hlxcommunity.com
 			}
 			if (!isset($minEvent))
 			{
-				$minEvent = split("-", $dates[$rank_type-1]['eventTime']);
+				$minEvent = explode("-", $dates[$rank_type-1]['eventTime']);
 				$minEvent = mktime(0, 0, 0, $minEvent[1], $minEvent[2], $minEvent[0]);
 				$maxEvent = $minEvent + 86400;
 			}


### PR DESCRIPTION
```
Uncaught Error: Call to undefined function split() in /home/ubuntu/hlstatsx/web/pages/players.php:347
Stack trace:
#0 /home/ubuntu/hlstatsx/web/hlstats.php(224): include()
#1 {main}
  thrown in /home/ubuntu/hlstatsx/web/pages/players.php on line 347,
```