### PR TITLE
Systemd services that replace the insecure shell start script

### DIFF
--- a/systemd/hlstatsx.service
+++ b/systemd/hlstatsx.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=hlstatsx statistics server
+After=cssource.service
+After=csgo.service
+After=teamfortress2.service
+
+[Service]
+ExecStart=/opt/hlstatsx/scripts/hlstats.pl --configfile=hlstats.conf --port=27500
+User=hlstatsx
+WorkingDirectory=/opt/hlstatsx/scripts
+SyslogIdentifier=hlstatsx
+
+Restart=always
+StartLimitBurst=3
+StartLimitBurstInterval=30
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/hlstatsx@.service
+++ b/systemd/hlstatsx@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=hlstatsx statistics server
+After=cssource.service
+After=csgo.service
+After=teamfortress2.service
+
+[Service]
+ExecStart=/opt/hlstatsx/scripts/hlstats.pl --configfile=hlstats.conf --port=%i
+User=hlstatsx
+WorkingDirectory=/opt/hlstatsx/scripts
+SyslogIdentifier=hlstatsx
+
+Restart=always
+StartLimitBurst=3
+StartLimitBurstInterval=30
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since I've just now had trouble getting your start script to run (I prefer not giving daemons write access to their binary directories, for obvious reasons), I ditched it for good and just wrote a systemd service that executes the Perl script directly and has its eyes on it all the time (as opposed to the shell script that only can check now and then).

You are welcome to use them. If you got questions or further requests, just give me a heads up. I've sent you a Steam friend request, so you may chat directly too.