### PR TITLE
More fixes for Geo IP v2

### DIFF
--- a/scripts/GeoLiteCity/GeoLite_Import.sh
+++ b/scripts/GeoLiteCity/GeoLite_Import.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # HLstatsX Community Edition - Real-time player and clan rankings and statistics
 # Copyleft (L) 2008-20XX Nicholas Hastings (nshastings@gmail.com)
 # http://www.hlxcommunity.com
@@ -34,37 +34,88 @@
 # 
 # For support and installation notes visit http://www.hlxcommunity.com
 
-# Configure the variables below
+# Configure the variables below 
 
-# Set this value to 1 if you are running Gentoo linux, or any other linux distro where the "cal" command outputs not Sunday as the first day in every row!
-LINUX_OTHER="0" 
-
-# Login information for your MySQL server
+# Login information for your MySQL server.
+# DB Tables are created during initial MySQL DB creation
+# so point this to the same DB as your HLSX:CE install
 DBHOST="localhost"
-DBNAME=""
-DBUSER=""
-DBPASS=""
+DBNAME="<YOUR_DB_NAME>"
+DBUSER="<YOUR_DB_USER>"
+DBPASS="<YOUR_DB_PASS>"
+
+# Maximind API Key
+API_KEY="<YOUR_API_KEY>"
 
 #
 # Nothing to change below here.
 #
 
+# Set API address and file name
+API_URL="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&license_key=$API_KEY&suffix=zip"
+FILE="GeoLiteCity-CSV.zip"
 
-FILE="GeoLiteCity-latest.zip"
-rm -f geoLiteCity_Blocks.csv
-rm -f geoLiteCity_Location.csv
-rm -f geoLiteCity_Location.csv.temp
-rm -f $FILE
-[ -f $FILE ] || wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/$FILE || exit 1
-unzip -jo $FILE || exit 1
-mv GeoLiteCity-Blocks.csv geoLiteCity_Blocks.csv
-mv GeoLiteCity-Location.csv geoLiteCity_Location.csv.temp
-iconv -f ISO-8859-1 -t UTF-8 geoLiteCity_Location.csv.temp > geoLiteCity_Location.csv
-mysqlimport -C -d --fields-terminated-by=, --fields-enclosed-by=\" --ignore-lines=2 --default-character-set=utf8 -L -i -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLiteCity_Blocks.csv 
-mysqlimport -C -d --fields-terminated-by=, --fields-enclosed-by=\" --ignore-lines=2 --default-character-set=utf8 -L -i -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLiteCity_Location.csv 
+# Change to directory where installer is
+cd `dirname $0`
+
+# Error check for API key
+if [[ $API_KEY =~ "<YOUR_API_KEY>" ]]; then
+  echo "----------------------------------------------------------"
+  echo "[!] You probably forgot to set yours MaxMind account API key!"
+  echo "[i] Please check installation instructions > 2.4. Prepare GeoIP2 (optional) > https://github.com/NomisCZ/hlstatsx-community-edition/wiki/Installation#2-installation"
+  echo "----------------------------------------------------------"
+  exit 3
+fi
+
+#Download zip
+echo "[>>] Downloading GeoLite2-City database"
+wget -N -q $API_URL -O $FILE
+echo "[<<] Download complete"
+
+#Decompress zip
+echo "[>>] Decompressing $FILE$FILE_EXT"
+unzip -jo $FILE
+echo "[<<] Decompress complete"
+
+#Process blocks
+echo "[>>] Processing Blocks"
+mv GeoLite2-City-Blocks-IPv4.csv geoLite2_City_Blocks_IPv4.csv
+echo "[<<] Processing complete"
+
+#Import blocks to MySQL
+echo "[>>] Importing Blocks to MySQL - THIS MIGHT TAKE SOME TIME!"
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Blocks_IPv4.csv
+echo "[<<] Import IPv4 complete"
+
+#Process locations
+echo "[>>] Processing locations"
+mv GeoLite2-City-Locations-de.csv geoLite2_City_Location_de.csv
+mv GeoLite2-City-Locations-en.csv geoLite2_City_Location_en.csv
+mv GeoLite2-City-Locations-es.csv geoLite2_City_Location_es.csv
+mv GeoLite2-City-Locations-fr.csv geoLite2_City_Location_fr.csv
+mv GeoLite2-City-Locations-ja.csv geoLite2_City_Location_ja.csv
+mv GeoLite2-City-Locations-pt-BR.csv geoLite2_City_Location_pt_BR.csv
+mv GeoLite2-City-Locations-ru.csv geoLite2_City_Location_ru.csv
+mv GeoLite2-City-Locations-zh-CN.csv geoLite2_City_Location_zh_CN.csv
+echo "[<<] Processing complete"
+
+#Import locations to MySQL
+echo "[>>] Importing Locations to MySQL - THIS MIGHT TAKE SOME TIME!"
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_de.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_en.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_es.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_fr.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_ja.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_pt_BR.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_ru.csv
+mysqlimport --fields-terminated-by=, --ignore-lines=1 --default-character-set=utf8 -L -h $DBHOST -u $DBUSER --password=$DBPASS $DBNAME geoLite2_City_Location_zh_CN.csv
+echo "[<<] Importing complete"
+
 
 # Cleanup
-rm -f geoLiteCity_Blocks.csv
-rm -f geoLiteCity_Location.csv
-rm -f geoLiteCity_Location.csv.temp
+echo "[>>] Cleanup"
+cd `dirname $0`
+rm -f *.csv
+rm -f *.txt
 rm -f $FILE
+echo "[<<] Cleanup complete"

--- a/scripts/GeoLiteCity/GeoLite_Import.sh
+++ b/scripts/GeoLiteCity/GeoLite_Import.sh
@@ -115,7 +115,7 @@ echo "[<<] Importing complete"
 # Cleanup
 echo "[>>] Cleanup"
 cd `dirname $0`
-rm -f *.csv
-rm -f *.txt
+rm -f ./*.csv
+rm -f ./*.txt
 rm -f $FILE
 echo "[<<] Cleanup complete"

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -2,36 +2,176 @@
 
 -- This file is only needed for new installations.
 
-SET @DBVERSION="80";
+SET @DBVERSION="81";
 SET @VERSION="1.7.0";
 
 -- --------------------------------------------------------
 
 --
--- Table structure for table `geoLiteCity_Blocks`
+-- Table structure for table `geoLite2_City_Blocks_IPv4`
 --
 
-CREATE TABLE IF NOT EXISTS `geoLiteCity_Blocks` (
-  `startIpNum` bigint(11) unsigned NOT NULL default '0',
-  `endIpNum` bigint(11) unsigned NOT NULL default '0',
-  `locId` bigint(11) unsigned NOT NULL default '0'
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Blocks_IPv4` (
+  `network` varchar(24) NOT NULL default '0',
+  `geoname_id` mediumint NOT NULL default '0',
+  `registered_country_geoname_id` mediumint NOT NULL default '0',
+  `represented_country_geoname_id,` mediumint default NULL,
+  `is_anonymous_proxy` tinyint NOT NULL default '0',
+  `is_satellite_provider` tinyint NOT NULL default '0',
+  `postal_code` varchar(8) default NULL,
+  `latitude` decimal(14,4) unsigned NOT NULL default '0',
+  `longitude` decimal(14,4) unsigned NOT NULL default '0',
+  `accuracy_radius` smallint NOT NULL default '0'
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
 --
--- Table structure for table `geoLiteCity_Location`
+-- Table structure for table `geoLite2_City_Locations`
 --
 
-CREATE TABLE IF NOT EXISTS `geoLiteCity_Location` (
-  `locId` bigint(11) unsigned NOT NULL default '0',
-  `country` varchar(2) NOT NULL,
-  `region` varchar(50) default NULL,
-  `city` varchar(50) default NULL,
-  `postalCode` varchar(10) default NULL,
-  `latitude` decimal(14,4) default NULL,
-  `longitude` decimal(14,4) default NULL,
-  PRIMARY KEY  (`locId`)
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_de` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_en` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_es` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_fr` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_ja` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_pt_BR` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_ru` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `geoLite2_City_Location_zh_CN` (
+  `geoname_id` int NOT NULL,
+  `locale_code` varchar(2) NOT NULL,
+  `continent_code` varchar(2) default NULL,
+  `continent_name` varchar(20) default NULL,
+  `country_iso_code` varchar(2) default NULL,
+  `country_name` varchar(50) default NULL,
+  `subdivision_1_iso_code` varchar(3) default NULL,
+  `subdivision_1_name` varchar(50) default NULL,
+  `subdivision_2_iso_code` varchar(3) default NULL,
+  `subdivision_2_name` varchar(50) default NULL,
+  `city_name` varchar(50) default NULL,
+  `metro_code` mediumint default NULL,
+  `time_zone` varchar(20) NOT NULL,
+  `is_in_european_union` tinyint NOT NULL default '0',
+  PRIMARY KEY  (`geoname_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -4061,6 +4201,7 @@ INSERT INTO `hlstats_Options_Choices` (`keyname`, `value`, `text`, `isDefault`) 
 ('display_gamelist', '0', 'No', 0),
 ('display_style_selector', '1', 'Yes', 0),
 ('display_style_selector', '0', 'No', 1);
+
 -- --------------------------------------------------------
 
 --
@@ -4082,6 +4223,8 @@ CREATE TABLE IF NOT EXISTS `hlstats_PlayerNames` (
   PRIMARY KEY  (`playerId`,`name`),
   KEY `name16` (`name`(16))
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `hlstats_Players`

--- a/web/pages/admintasks/options.php
+++ b/web/pages/admintasks/options.php
@@ -225,7 +225,7 @@ RewriteRule sig-(.*)-(.*).png$ sig.php?player_id=$1&background=$2 [L]</textarea>
 	$optiongroups[1]->options[] = new Option('show_google_map', 'Show Google worldmap', 'select');
 	$optiongroups[1]->options[] = new Option('google_map_region', 'Google Maps Region', 'select');
 	$optiongroups[1]->options[] = new Option('google_map_type', 'Google Maps Type', 'select');
-	$optiongroups[1]->options[] = new Option('UseGeoIPBinary', '*Choose whether to use GeoCityLite data loaded into mysql database or from binary file. (If binary, GeoLiteCity.dat goes in perl/GeoLiteCity and Geo::IP::PurePerl module is required', 'select');
+	$optiongroups[1]->options[] = new Option('UseGeoIPBinary', '*Choose whether to use GeoCityLite data loaded into mysql database or from binary file. (If binary, GeoIP V2 is required, see https://github.com/NomisCZ/hlstatsx-community-edition/wiki/Installation', 'select');
 
 	$optiongroups[2] = new OptionGroup('Awards settings');
 	$optiongroups[2]->options[] = new Option('gamehome_show_awards', 'Show daily award winners on Game Frontpage', 'select');


### PR DESCRIPTION
1) Updated install.sql to create tables in Geo IP V2 expected format. (Note, the SQL script throws an error which was imported from your original script, afaict there is no issue and everything still imports correctly)
2) Updated geolite_import.sh to download the V2 CSVs using a Maxmind key, rename them all and import into MySQL.
3) Removed legacy reference to Geo IP V1 from options panel in admin tasks.