### PR TITLE
Change MD5 to RipeMD128

### DIFF
--- a/web/pages/admin.php
+++ b/web/pages/admin.php
@@ -143,7 +143,6 @@ class Auth
 			$this->userdata = $db->fetch_array();
 			$db->free_result();
 			
-			#if (md5($this->password) == $this->userdata["password"])
 			if (hash("ripemd128", $this->password) == $this->userdata["password"])
 			{
 				// The username and the password are OK
@@ -372,7 +371,7 @@ class EditList
 					
 					if ($col->type == 'password' && $col->name != 'rcon_password')
 					{
-						#$value = md5($value);
+					
 						
 						$value = hash("ripemd128", $value, );
 					}

--- a/web/pages/admin.php
+++ b/web/pages/admin.php
@@ -142,7 +142,6 @@ class Auth
 
 			$this->userdata = $db->fetch_array();
 			$db->free_result();
-			
 			if (hash("ripemd128", $this->password) == $this->userdata["password"])
 			{
 				// The username and the password are OK
@@ -371,8 +370,6 @@ class EditList
 					
 					if ($col->type == 'password' && $col->name != 'rcon_password')
 					{
-					
-						
 						$value = hash("ripemd128", $value, );
 					}
 					$qvals .= "'" . $db->escape($value) . "'";

--- a/web/pages/admin.php
+++ b/web/pages/admin.php
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 For support and installation notes visit http://www.hlxcommunity.com
 */
 
+
 if (!defined('IN_HLSTATS'))
 {
 	die('Do not access this file directly.');
@@ -141,8 +142,9 @@ class Auth
 
 			$this->userdata = $db->fetch_array();
 			$db->free_result();
-
-			if (md5($this->password) == $this->userdata["password"])
+			
+			#if (md5($this->password) == $this->userdata["password"])
+			if (hash("ripemd128", $this->password) == $this->userdata["password"])
 			{
 				// The username and the password are OK
 
@@ -367,10 +369,12 @@ class EditList
 					{
 						$qvals .= ', ';
 					}
-
+					
 					if ($col->type == 'password' && $col->name != 'rcon_password')
 					{
-						$value = md5($value);
+						#$value = md5($value);
+						
+						$value = hash("ripemd128", $value, );
 					}
 					$qvals .= "'" . $db->escape($value) . "'";
 
@@ -480,7 +484,7 @@ class EditList
 
 					if ($col->type == 'password' && $col->name != 'rcon_password')
 					{
-						$query .= $col->name . "='" . md5($value) . "'";
+						$query .= $col->name . "='" . hash("ripemd128",$value) . "'";
 					}
 					else
 					{


### PR DESCRIPTION
This change removed the use of MD5 and impliments RipeMD128, in theory the code now allows for ANY hash algorithm PHP supports to be used. Tested on my production setup running PHP 7.4